### PR TITLE
Enable the library to parse eduPersonTargetedID value

### DIFF
--- a/samlsp/session_jwt.go
+++ b/samlsp/session_jwt.go
@@ -56,7 +56,11 @@ func (c JWTSessionCodec) New(assertion *saml.Assertion) (Session, error) {
 				claimName = attr.Name
 			}
 			for _, value := range attr.Values {
-				claims.Attributes[claimName] = append(claims.Attributes[claimName], value.Value)
+				if value.Value == "" && value.NameID != nil {
+					claims.Attributes[claimName] = append(claims.Attributes[claimName], value.NameID.Value) // cater to eduPersonTargetedID
+				} else {
+					claims.Attributes[claimName] = append(claims.Attributes[claimName], value.Value)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This change allows the library to parse attributes such as the eduPersonTargetedID whose values is not found in the Values.value node but rather inside the the Values.NameID node.